### PR TITLE
Removes useless increment that gets reset on next loop

### DIFF
--- a/ranker/wordle/models.py
+++ b/ranker/wordle/models.py
@@ -39,7 +39,6 @@ class ActiveWordle(models.Model):
                     word_copy.pop(word_copy.index(letter))
                 else:
                     correct += "0"
-                j += 1
         return correct
 
     @property


### PR DESCRIPTION
Removes useless increment.  Run below in a python shell to easily prove it to yourself.

```
for i in range(10):  
    print(i)
    i += 1
```


if the i += 1 does nothing it should print 0 to 9.